### PR TITLE
'stop' should be treated specially in DBGp() too

### DIFF
--- a/dbgp.ahk
+++ b/dbgp.ahk
@@ -118,7 +118,7 @@ DBGp(session, command, args="", ByRef response="")
     
     ; If OnBreak has been set and this is a continuation command,
     ; call OnBreak when the response is received instead of waiting.
-    if InStr(" run step_into step_over step_out ", " " command " ")
+    if InStr(" run step_into step_over step_out stop ", " " command " ")
         handler := DBGp_Session.OnBreak
     else
         handler := ""


### PR DESCRIPTION
`stop` is a DBGp command that should be treated like `run` or `step_into`. If this is not done, S4AHK's debugger crashes when you try to stop debugging.
